### PR TITLE
Add TypeScript SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /vendor/
+
+/dist/

--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ var_export($sdk->getResponseArray($handleReadEstate));
 Checkout the [examples folder](/examples/) to see a possible implementation of
 this client.
 
+## TypeScript Usage
+
+This repository also provides a lightweight TypeScript client located in the
+`typescript` folder. Build the library with `npm run build` and import it in
+your project:
+
+```typescript
+import OnOfficeSDK from './dist';
+
+const sdk = new OnOfficeSDK();
+sdk.setApiVersion('stable');
+const handle = sdk.callGeneric(OnOfficeSDK.ACTION_ID_READ, 'estate', {
+  listlimit: 5
+});
+await sdk.sendRequests('your token', 'your secret');
+console.log(sdk.getResponseArray(handle));
+```
+
 ## Usage
 
 ### Client

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "onoffice-sdk-ts",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "typescript",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "skipLibCheck": true
+  },
+  "include": ["typescript/**/*"]
+}

--- a/typescript/OnOfficeSDK.ts
+++ b/typescript/OnOfficeSDK.ts
@@ -1,0 +1,52 @@
+import { ApiCall } from './internal/ApiCall';
+
+export class OnOfficeSDK {
+  static ACTION_ID_READ = 'urn:onoffice-de-ns:smart:2.5:smartml:action:read';
+  static ACTION_ID_CREATE = 'urn:onoffice-de-ns:smart:2.5:smartml:action:create';
+  static ACTION_ID_MODIFY = 'urn:onoffice-de-ns:smart:2.5:smartml:action:modify';
+  static ACTION_ID_GET = 'urn:onoffice-de-ns:smart:2.5:smartml:action:get';
+  static ACTION_ID_DO = 'urn:onoffice-de-ns:smart:2.5:smartml:action:do';
+  static ACTION_ID_DELETE = 'urn:onoffice-de-ns:smart:2.5:smartml:action:delete';
+
+  private apiCall: ApiCall;
+
+  constructor(apiCall?: ApiCall) {
+    this.apiCall = apiCall ?? new ApiCall();
+  }
+
+  setApiVersion(version: string) {
+    this.apiCall.setApiVersion(version);
+  }
+
+  setApiServer(server: string) {
+    this.apiCall.setServer(server);
+  }
+
+  callGeneric(actionId: string, resourceType: string, parameters: any) {
+    return this.apiCall.callByRawData(actionId, '', '', resourceType, parameters);
+  }
+
+  call(
+    actionId: string,
+    resourceId: string,
+    identifier: string,
+    resourceType: string,
+    parameters: any
+  ) {
+    return this.apiCall.callByRawData(actionId, resourceId, identifier, resourceType, parameters);
+  }
+
+  async sendRequests(token: string, secret: string) {
+    await this.apiCall.sendRequests(token, secret);
+  }
+
+  getResponseArray(number: number) {
+    return this.apiCall.getResponse(number);
+  }
+
+  getErrors() {
+    return this.apiCall.getErrors();
+  }
+}
+
+export default OnOfficeSDK;

--- a/typescript/index.ts
+++ b/typescript/index.ts
@@ -1,0 +1,1 @@
+export { OnOfficeSDK as default, OnOfficeSDK } from './OnOfficeSDK';

--- a/typescript/internal/ApiAction.ts
+++ b/typescript/internal/ApiAction.ts
@@ -1,0 +1,45 @@
+declare function require(name: string): any;
+const crypto = require('crypto');
+
+export interface ApiParameters {
+  [key: string]: any;
+}
+
+export class ApiAction {
+  private actionParameters: Record<string, any>;
+
+  constructor(
+    actionId: string,
+    resourceType: string,
+    parameters: ApiParameters,
+    resourceId: string = '',
+    identifier: string = '',
+    timestamp?: number
+  ) {
+    const sortedParams = Object.keys(parameters)
+      .sort()
+      .reduce((acc: any, key) => {
+        acc[key] = parameters[key];
+        return acc;
+      }, {} as ApiParameters);
+    this.actionParameters = {
+      actionid: actionId,
+      identifier,
+      parameters: sortedParams,
+      resourceid: resourceId,
+      resourcetype: resourceType,
+      timestamp,
+    };
+  }
+
+  getActionParameters() {
+    return this.actionParameters;
+  }
+
+  getIdentifier() {
+    return crypto
+      .createHash('md5')
+      .update(JSON.stringify(this.actionParameters))
+      .digest('hex');
+  }
+}

--- a/typescript/internal/ApiCall.ts
+++ b/typescript/internal/ApiCall.ts
@@ -1,0 +1,91 @@
+import { Request } from './Request';
+import { ApiAction } from './ApiAction';
+import { Response } from './Response';
+
+export class ApiCall {
+  private requestQueue: Map<number, Request> = new Map();
+  private responses: Map<number, Response> = new Map();
+  private errors: Map<number, any> = new Map();
+  private apiVersion = 'stable';
+  private server = 'https://api.onoffice.de/api/';
+
+  callByRawData(
+    actionId: string,
+    resourceId: string,
+    identifier: string,
+    resourceType: string,
+    parameters: Record<string, any> = {}
+  ) {
+    const action = new ApiAction(actionId, resourceType, parameters, resourceId, identifier);
+    const request = new Request(action);
+    const requestId = request.getRequestId();
+    this.requestQueue.set(requestId, request);
+    return requestId;
+  }
+
+  async sendRequests(token: string, secret: string) {
+    const actionParameters: any[] = [];
+    const actionOrder: Request[] = [];
+
+    for (const [id, request] of this.requestQueue) {
+      const params = request.createRequest(token, secret);
+      actionParameters.push(params);
+      actionOrder.push(request);
+    }
+
+    if (actionParameters.length === 0) {
+      return;
+    }
+
+    const requestBody = {
+      token,
+      request: {
+        actions: actionParameters,
+      },
+    };
+
+    const url = `${this.server}${encodeURIComponent(this.apiVersion)}/api.php`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(requestBody),
+    });
+    const json = await res.json();
+    if (!json.response || !json.response.results) {
+      throw new Error('No result from API');
+    }
+    json.response.results.forEach((result: any, index: number) => {
+      const req = actionOrder[index];
+      const id = req.getRequestId();
+      if (result.status && result.status.errorcode === 0) {
+        this.responses.set(id, new Response(req, result));
+      } else {
+        this.errors.set(id, result);
+      }
+    });
+    this.requestQueue.clear();
+  }
+
+  getResponse(handle: number) {
+    const resp = this.responses.get(handle);
+    if (resp) {
+      this.responses.delete(handle);
+      return resp.getResponseData();
+    }
+    return undefined;
+  }
+
+  setApiVersion(version: string) {
+    this.apiVersion = version;
+  }
+
+  setServer(server: string) {
+    this.server = server;
+  }
+
+  getErrors() {
+    return Array.from(this.errors.values());
+  }
+}

--- a/typescript/internal/Request.ts
+++ b/typescript/internal/Request.ts
@@ -1,0 +1,40 @@
+import { ApiAction } from './ApiAction';
+declare function require(name: string): any;
+const crypto = require('crypto');
+
+export class Request {
+  private apiAction: ApiAction;
+  private requestId: number;
+  private static requestIdStatic = 0;
+
+  constructor(apiAction: ApiAction) {
+    this.apiAction = apiAction;
+    this.requestId = Request.requestIdStatic++;
+  }
+
+  createRequest(token: string, secret: string) {
+    const params = { ...this.apiAction.getActionParameters() };
+    params.timestamp = params.timestamp ?? Math.floor(Date.now() / 1000);
+    params.hmac_version = 2;
+    const fields = {
+      timestamp: params.timestamp,
+      token,
+      resourcetype: params.resourcetype,
+      actionid: params.actionid,
+    };
+    const hmac = crypto
+      .createHmac('sha256', secret)
+      .update(Object.values(fields).join(''))
+      .digest();
+    params.hmac = hmac.toString('base64');
+    return params;
+  }
+
+  getRequestId() {
+    return this.requestId;
+  }
+
+  getApiAction() {
+    return this.apiAction;
+  }
+}

--- a/typescript/internal/Response.ts
+++ b/typescript/internal/Response.ts
@@ -1,0 +1,23 @@
+import { Request } from './Request';
+
+export class Response {
+  constructor(private request: Request, private responseData: any) {}
+
+  isValid() {
+    return (
+      this.responseData &&
+      typeof this.responseData === 'object' &&
+      'actionid' in this.responseData &&
+      'resourcetype' in this.responseData &&
+      'data' in this.responseData
+    );
+  }
+
+  getRequest() {
+    return this.request;
+  }
+
+  getResponseData() {
+    return this.responseData;
+  }
+}


### PR DESCRIPTION
## Summary
- add a TypeScript implementation of the onOffice SDK
- document how to use the TypeScript client in README
- ignore built output via dist/

## Testing
- `npm run build`
- ❌ `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6879de81ff688321aa44a07a55421b95